### PR TITLE
fix(server): import jwt in auth middleware and mount modular routers (#11)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,9 @@ const { authMiddleware } = require('./middleware/auth');
 const { errorHandler } = require('./middleware/errorHandler');
 const { limiter } = require('./middleware/rateLimiter');
 
+const authRoutes = require('./routes/auth');
+const documentRoutes = require('./routes/documents');
+
 const app = express();
 
 app.use(helmet());
@@ -112,29 +115,12 @@ app.post('/api/v1/verify', upload.single('file'), asyncHandler(async (req, res) 
   }, 'Verification complete');
 }));
 
-// Public documents route (no auth for now)
-app.get('/api/v1/documents', asyncHandler(async (req, res) => {
-  const page = parseInt(req.query.page) || 1;
-  const limit = parseInt(req.query.limit) || 20;
-  const skip = (page - 1) * limit;
-
-  const docs = await Document.find()
-    .sort({ createdAt: -1 })
-    .skip(skip)
-    .limit(limit);
-
-  const total = await Document.countDocuments();
-
-  success(res, {
-    documents: docs,
-    pagination: {
-      page,
-      limit,
-      total,
-      pages: Math.ceil(total / limit)
-    }
-  }, 'Documents retrieved');
-}));
+// Mount modular routers so the /api/v1/auth and /api/v1/documents
+// route files actually reach Express instead of being dead code
+// (issue #11). The previous inline /api/v1/documents handler duplicated
+// routes/documents.js, so drop it in favour of the single source.
+app.use('/api/v1/auth', authRoutes);
+app.use('/api/v1/documents', documentRoutes);
 
 app.use(errorHandler);
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,3 +1,4 @@
+const jwt = require('jsonwebtoken');
 const { AppError } = require('../errors/AppError');
 
 const authMiddleware = (req, res, next) => {


### PR DESCRIPTION
## Summary

Two orthogonal but related bugs from the issue:

1. **`server/middleware/auth.js`** referenced `jwt.verify` without requiring `jsonwebtoken`, so the first authenticated request would throw `ReferenceError: jwt is not defined`. Added the missing `const jwt = require('jsonwebtoken');`.

2. **`server/index.js`** imported `authMiddleware` and defined an inline `/api/v1/documents` handler but never mounted `server/routes/auth.js` or `server/routes/documents.js`. Mounted both routers via `app.use('/api/v1/auth', authRoutes)` / `app.use('/api/v1/documents', documentRoutes)` and dropped the duplicated inline documents handler — `routes/documents.js` is now the single source for that path.

Fixes #11

## Test plan

- [x] `node --check server/index.js` — clean
- [x] `node -e "require('./server/index.js')"` — loads without crashing (only env-var warnings, unrelated)
- [x] `node -e "require('./server/middleware/auth.js').authMiddleware"` — auth middleware resolves to a function (previously would throw when called)